### PR TITLE
Require WP_SCRIPT_DEBUG and HM_GUTENBERG_WIDGETS_DEBUG to enable debug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,13 @@ A Gutenberg plugin to add a blocks for classic widget areas.
 
 - Widget area preview
 - Individual classic widget block
+
+## To enable debug mode
+
+In your project `wp-config.php` (or equivalent), ensure the following constants are set:
+
+```
+define( 'SCRIPT_DEBUG', true );
+define( 'HM_GUTENBERG_WIDGETS_DEBUG', true );
+```
+

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -25,7 +25,7 @@ function enqueue_editor_assets() {
 	$path = 'assets/dist/main.js';
 	$src  = plugins_url( $path, $plugin_file_path );
 
-	if ( ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) || ( defined( 'HM_GUTENBERG_WIDGETS_DEBUG' ) && HM_GUTENBERG_WIDGETS_DEBUG ) ) {
+	if ( ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) && ( defined( 'HM_GUTENBERG_WIDGETS_DEBUG' ) && HM_GUTENBERG_WIDGETS_DEBUG ) ) {
 		$src = str_replace( content_url(), 'https://localhost:8884', $src );
 		$ver = null;
 	} else {


### PR DESCRIPTION
I had an issue where we had other scripts needing `script_debug` set to true, but didn't actually need the debug version of hm_gutenberg_widgets running.

Setting `HM_GUTENBERG_WIDGETS_DEBUG` to false didn't actually stop this, not :100: whether this is the best way to handle the development setting of this plugin tbh, but I've updated the readme to reflect the change for future use in the hopes to clear that up.